### PR TITLE
Fixed typo in feed_items_max

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -16,7 +16,7 @@ collections:
     categories: true
     categories_metadata: true
     authors_metadata: false
-    feed_iems_max: 20 # default
+    feed_items_max: 20 # default
     disqus: statistical-genetics
     share: [twitter, linkedin]
     subscribe: _subscribe.html


### PR DESCRIPTION
Hi Emi! I dig the new website. I am moving over to distill as well and used your site to figure out how a lot of this works. I noticed a typo in your `_site.yml` file for how many posts your blog shows (which was irrelevant because you had it set to the default) so I fixed it. Cheers!